### PR TITLE
Add a settings page for updating account details, preferences, password, and deletion

### DIFF
--- a/backend/core/accounts/urls.py
+++ b/backend/core/accounts/urls.py
@@ -5,21 +5,23 @@ from rest_framework_simplejwt.views import TokenRefreshView
 from rest_framework_simplejwt.views import TokenObtainPairView
 
 from .views import (
-    UserDetailView,
     RegisterView,
     LogoutView,
-    UserDetailByUsernameView,
+    UserDetailView,
+    UserDetailUpdateDeleteView,
+    ChangePasswordView,
     UserPreferencesView,
     UserFavouritesView,
 )
 
 urlpatterns = [
-    path("register/", RegisterView.as_view(), name="register"),
-    path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
-    path("users/me/", UserDetailView.as_view(), name="user_detail"),
-    path("logout/", LogoutView.as_view(), name="logout"),
-    path("users/<str:username>/", UserDetailByUsernameView.as_view(), name="user_detail_by_username"),
-    path("users/<str:username>/preferences/", UserPreferencesView.as_view(), name="user_preferences"),
-    path("users/<str:username>/favourites/", UserFavouritesView.as_view(), name="user_favourites"),
+    path('register/', RegisterView.as_view(), name='register'),
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('users/me/', UserDetailView.as_view(), name='user_detail_me'),
+    path('logout/', LogoutView.as_view(), name='logout'),
+    path('users/<str:username>/', UserDetailUpdateDeleteView.as_view(), name='user_detail_update_delete'),
+    path('users/<str:username>/password/', ChangePasswordView.as_view(), name='change_password'),
+    path('users/<str:username>/preferences/', UserPreferencesView.as_view(), name='user_preferences'),
+    path('users/<str:username>/favourites/', UserFavouritesView.as_view(), name='user_favourites'),
 ]

--- a/backend/core/accounts/views.py
+++ b/backend/core/accounts/views.py
@@ -77,8 +77,6 @@ class UserDetailUpdateDeleteView(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = [permissions.IsAuthenticated, IsOwnerOrAdmin]
 
     def update(self, request, *args, **kwargs):
-        print("→ request.user.username:", request.user.username)
-        print("→ URL username param:", self.kwargs['username'])
         # Check ownership/admin
         username = self.kwargs['username']
         if request.user.username != username and not request.user.is_staff:

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,17 @@
+// src/app/settings/page.tsx
+
+import SettingsInner from '@/components/settings/SettingsInner'
+import ClientOnly from '@/components/shared/ClientOnly'
+
+const SettingsPage = () => {
+  return (
+    <div className="flex flex-col items-center w-full mx-auto p-6 space-y-8">
+      <h1 className="text-3xl font-bold">Account Settings</h1>
+      <ClientOnly>
+        <SettingsInner />
+      </ClientOnly>
+    </div>
+  )
+}
+
+export default SettingsPage

--- a/frontend/src/components/settings/AccountDetails.tsx
+++ b/frontend/src/components/settings/AccountDetails.tsx
@@ -1,0 +1,163 @@
+// src/components/settings/AccountDetails.tsx
+
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Pencil as PencilIcon, X as CrossIcon, Save as SaveIcon } from 'lucide-react'
+import { useAuth } from '@/context/AuthContext'
+import { UpdateDetailsSchema, type UpdateDetailsForm } from '@/lib/auth/validation'
+
+const fields: Array<keyof UpdateDetailsForm> = [
+  'username',
+  'email_address',
+  'first_name',
+  'last_name',
+]
+
+type Field = keyof UpdateDetailsForm
+
+const AccountDetails = () => {
+  const { user: me, authFetch } = useAuth()
+  const [form, setForm] = useState<UpdateDetailsForm>({
+    username: '',
+    email_address: '',
+    first_name: '',
+    last_name: '',
+  })
+  const [editing, setEditing] = useState<Field | null>(null)
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [errors, setErrors] = useState({ field: '', password: '' })
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!me) return
+    setForm({
+      username: me.username,
+      email_address: me.email,
+      first_name: me.first_name,
+      last_name: me.last_name,
+    })
+  }, [editing, me])
+
+  const startEdit = (field: Field) => {
+    if (saving) return
+    setErrors({ field: '', password: '' })
+    setEditing(field)
+  }
+
+  const cancelEdit = () => {
+    if (!editing) return
+    setErrors({ field: '', password: '' })
+    setForm((prev) => ({ ...prev, [editing]: prev[editing] as string }))
+    setCurrentPassword('')
+    setEditing(null)
+  }
+
+  const handleFieldSave = async () => {
+    if (!editing) return
+    setErrors({ field: '', password: '' })
+    setSaving(true)
+
+    // Zod validation: get specific field schema
+    const shape = UpdateDetailsSchema.shape
+    const schema = shape[editing]
+    const parsed = schema.safeParse(form[editing])
+    if (!parsed.success) {
+      setErrors({ field: parsed.error.errors[0].message, password: '' })
+      setSaving(false)
+      return
+    }
+
+    if (!currentPassword) {
+      setErrors({ field: '', password: 'Enter your current password' })
+      setSaving(false)
+      return
+    }
+
+    const payload: Partial<UpdateDetailsForm> & { password: string } = {
+      [editing]: form[editing],
+      password: currentPassword,
+    }
+
+    try {
+      const res = await authFetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_API_URL}/api/accounts/users/${me!.username}/`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        },
+      )
+      if (!res.ok) throw new Error()
+      setEditing(null)
+      setCurrentPassword('')
+    } catch {
+      setErrors({ field: '', password: 'Failed. Check your password.' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold">Account Details</h3>
+      {fields.map((field) => (
+        <div key={field} className="space-y-1">
+          <span className="text-sm capitalize ml-3">{field.replace('_', ' ')}</span>
+          <div className="flex flex-row items-center space-x-4">
+            <input
+              className="input input-bordered max-w-80"
+              value={form[field] as string}
+              placeholder={`Enter your ${field.replace('_', ' ')}`}
+              disabled={editing !== field || saving}
+              onChange={(e) => setForm((prev) => ({ ...prev, [field]: e.target.value }))}
+            />
+            <div className="flex-grow" />
+            {editing !== field ? (
+              <button
+                className="btn btn-sm btn-outline px-2"
+                onClick={() => startEdit(field)}
+                disabled={saving}
+              >
+                <PencilIcon size={16} strokeWidth={3} />
+              </button>
+            ) : (
+              <div className="flex space-x-2">
+                <input
+                  type="password"
+                  placeholder="Enter your password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  className="input input-bordered input-sm"
+                  disabled={saving}
+                />
+                <button
+                  className="btn btn-sm btn-primary px-2"
+                  onClick={handleFieldSave}
+                  disabled={saving}
+                >
+                  <SaveIcon size={16} strokeWidth={3} />
+                </button>
+                <button
+                  className="btn btn-sm btn-outline btn-error px-2"
+                  onClick={cancelEdit}
+                  disabled={saving}
+                >
+                  <CrossIcon size={16} strokeWidth={3} />
+                </button>
+              </div>
+            )}
+          </div>
+          {editing === field && errors.field && (
+            <p className="text-xs text-red-500">{errors.field}</p>
+          )}
+          {editing === field && errors.password && (
+            <p className="text-xs text-red-500">{errors.password}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default AccountDetails

--- a/frontend/src/components/settings/AccountSettings.tsx
+++ b/frontend/src/components/settings/AccountSettings.tsx
@@ -1,0 +1,17 @@
+// src/components/settings/AccountSettings.tsx
+
+import AccountDetails from '@/components/settings/AccountDetails'
+import ChangePassword from '@/components/settings/ChangePassword'
+import DeleteAccount from '@/components/settings/DeleteAccount'
+
+const AccountSettings = () => {
+  return (
+    <div className="p-6 rounded-lg border space-y-6">
+      <AccountDetails />
+      <ChangePassword />
+      <DeleteAccount />
+    </div>
+  )
+}
+
+export default AccountSettings

--- a/frontend/src/components/settings/ChangePassword.tsx
+++ b/frontend/src/components/settings/ChangePassword.tsx
@@ -1,0 +1,137 @@
+// src/components/settings/ChangePassword.tsx
+
+'use client'
+
+import { useState } from 'react'
+import { useAuth } from '@/context/AuthContext'
+import { ChangePasswordSchema, type ChangePasswordForm } from '@/lib/auth/validation'
+
+const ChangePassword = () => {
+  const { user: me, authFetch } = useAuth()
+  const [editing, setEditing] = useState(false)
+  const [form, setForm] = useState<ChangePasswordForm>({
+    old_password: '',
+    password: '',
+    confirm_password: '',
+  })
+  const [errors, setErrors] = useState<Partial<Record<keyof ChangePasswordForm, string>>>({})
+  const [saving, setSaving] = useState(false)
+  const [success, setSuccess] = useState('')
+
+  const start = () => {
+    setErrors({})
+    setSuccess('')
+    setEditing(true)
+  }
+
+  const cancel = () => {
+    setEditing(false)
+    setForm({ old_password: '', password: '', confirm_password: '' })
+    setErrors({})
+    setSuccess('')
+  }
+
+  const handleSave = async () => {
+    setErrors({})
+    setSuccess('')
+
+    const result = ChangePasswordSchema.safeParse(form)
+    if (!result.success) {
+      const fieldErrors: Partial<Record<keyof ChangePasswordForm, string>> = {}
+      result.error.issues.forEach((issue) => {
+        const key = issue.path[0]
+        if (typeof key === 'string' && key in form) {
+          fieldErrors[key as keyof ChangePasswordForm] = issue.message
+        }
+      })
+      setErrors(fieldErrors)
+      return
+    }
+
+    setSaving(true)
+    try {
+      const res = await authFetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_API_URL}/api/accounts/users/${me!.username}/password/`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ old_password: form.old_password, password: form.password }),
+        },
+      )
+      if (!res.ok) throw new Error()
+      setSuccess('Password changed successfully')
+      setForm({ old_password: '', password: '', confirm_password: '' })
+      setEditing(false)
+    } catch {
+      setErrors({ old_password: 'Password change failed' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="pt-4 border-t space-y-2">
+      <h3 className="text-lg font-semibold">Password</h3>
+      {!editing ? (
+        <button className="btn btn-sm btn-outline" onClick={start} disabled={saving}>
+          Change password
+        </button>
+      ) : (
+        <div className="space-y-4 max-w-80">
+          <label className="flex flex-col">
+            <span className="text-sm mb-1">Current password</span>
+            <input
+              type="password"
+              value={form.old_password}
+              placeholder="Enter current password"
+              onChange={(e) => setForm((prev) => ({ ...prev, old_password: e.target.value }))}
+              className="input input-bordered w-full"
+              disabled={saving}
+            />
+            {errors.old_password && <p className="text-xs text-red-500">{errors.old_password}</p>}
+          </label>
+
+          <label className="flex flex-col">
+            <span className="text-sm mb-1">New password</span>
+            <input
+              type="password"
+              value={form.password}
+              placeholder="Enter new password"
+              onChange={(e) => setForm((prev) => ({ ...prev, password: e.target.value }))}
+              className="input input-bordered w-full"
+              disabled={saving}
+            />
+          </label>
+
+          <label className="flex flex-col">
+            <span className="text-sm mb-1">Confirm new password</span>
+            <input
+              type="password"
+              value={form.confirm_password}
+              placeholder="Confirm new password"
+              onChange={(e) => setForm((prev) => ({ ...prev, confirm_password: e.target.value }))}
+              className="input input-bordered w-full"
+              disabled={saving}
+            />
+            {errors.confirm_password && (
+              <p className="text-xs text-red-500">{errors.confirm_password}</p>
+            )}
+          </label>
+
+          <div className="flex space-x-2">
+            <button className="btn btn-sm btn-primary" onClick={handleSave} disabled={saving}>
+              Save
+            </button>
+            <button className="btn btn-sm btn-outline btn-error" onClick={cancel} disabled={saving}>
+              Cancel
+            </button>
+          </div>
+
+          {success && <p className="text-xs text-green-600">{success}</p>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ChangePassword

--- a/frontend/src/components/settings/DeleteAccount.tsx
+++ b/frontend/src/components/settings/DeleteAccount.tsx
@@ -55,6 +55,15 @@ const DeleteAccount = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             className="input input-bordered w-full"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleDelete()
+              }
+              if (e.key === 'Escape') {
+                setConfirming(false)
+                setError('')
+              }
+            }}
           />
           {error && <p className="text-xs text-red-500">{error}</p>}
           <div className="flex space-x-2">

--- a/frontend/src/components/settings/DeleteAccount.tsx
+++ b/frontend/src/components/settings/DeleteAccount.tsx
@@ -1,0 +1,82 @@
+// src/components/settings/DeleteAccount.tsx
+
+'use client'
+
+import { useState } from 'react'
+import { useAuth } from '@/context/AuthContext'
+import { useRouter } from 'next/navigation'
+
+const DeleteAccount = () => {
+  const { user: me, authFetch, signOut } = useAuth()
+  const router = useRouter()
+  const [confirming, setConfirming] = useState(false)
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleDelete = async () => {
+    setError('')
+    if (!password) {
+      setError('Enter your password to confirm')
+      return
+    }
+    try {
+      const res = await authFetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_API_URL}/api/accounts/users/${me!.username}/`,
+        {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ password }),
+        },
+      )
+      if (!res.ok) throw new Error()
+      await signOut()
+      router.push('/')
+    } catch {
+      setError('Deletion failed. Check your password.')
+    }
+  }
+
+  return (
+    <div className="pt-4 border-t space-y-2">
+      <h3 className="text-lg font-semibold text-red-600">Delete Account</h3>
+      {!confirming ? (
+        <button
+          className="btn btn-sm btn-outline btn-error"
+          onClick={() => {
+            setConfirming(true)
+            setError('')
+          }}
+        >
+          Delete account
+        </button>
+      ) : (
+        <div className="space-y-2 max-w-80">
+          <input
+            type="password"
+            placeholder="Enter your password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="input input-bordered w-full"
+          />
+          {error && <p className="text-xs text-red-500">{error}</p>}
+          <div className="flex space-x-2">
+            <button className="btn btn-sm btn-error" onClick={handleDelete}>
+              Confirm delete
+            </button>
+            <button
+              className="btn btn-sm btn-secondary"
+              onClick={() => {
+                setConfirming(false)
+                setError('')
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default DeleteAccount

--- a/frontend/src/components/settings/PreferenceSettings.tsx
+++ b/frontend/src/components/settings/PreferenceSettings.tsx
@@ -1,0 +1,98 @@
+// src/components/settings/PreferenceSettings.tsx
+
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useAuth } from '@/context/AuthContext'
+import { getUserPreferences, updateUserPreferences } from '@/lib/profile/api'
+import { UserPreferences } from '@/lib/profile/types'
+
+const PreferenceSettings = () => {
+  const { authFetch: rawAuthFetch, updateLocalPrefs, user: me } = useAuth()
+
+  // Wrap authFetch so it matches the standard fetch signature
+  const authFetch = (input: RequestInfo | URL, init?: RequestInit) =>
+    rawAuthFetch(input.toString(), init)
+
+  const [prefs, setPrefs] = useState<UserPreferences | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [updatingField, setUpdatingField] = useState<keyof UserPreferences | null>(null)
+
+  useEffect(() => {
+    if (!me) return
+    ;(async () => {
+      try {
+        const data = await getUserPreferences(authFetch, me.username)
+        setPrefs(data)
+        updateLocalPrefs(data)
+      } catch (error) {
+        console.error('Error fetching user preferences:', error)
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [me])
+
+  const handleToggle =
+    (field: keyof UserPreferences) => async (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (!prefs) return
+      const newValue = event.target.checked
+      setPrefs({ ...prefs, [field]: newValue })
+      setUpdatingField(field)
+
+      try {
+        await updateUserPreferences(authFetch, me!.username, { [field]: newValue })
+        updateLocalPrefs({ [field]: newValue })
+      } catch (error) {
+        console.error('Error updating user preferences:', error)
+        // Rollback
+        setPrefs(prefs)
+      } finally {
+        setUpdatingField(null)
+      }
+    }
+
+  if (loading) return <div className="p-4">Loading preferences...</div>
+  if (!prefs) return <div className="p-4">Unable to load preferences.</div>
+
+  return (
+    <div className="min-w-64 max-w-80 p-4 rounded-lg border-1">
+      <h2 className="text-lg font-semibold mb-3">User Preferences</h2>
+
+      <label className="flex items-center justify-between mb-2">
+        <span className="text-sm">Public profile</span>
+        <input
+          type="checkbox"
+          className="toggle toggle-primary"
+          checked={prefs.public_profile}
+          disabled={updatingField === 'public_profile'}
+          onChange={handleToggle('public_profile')}
+        />
+      </label>
+
+      <label className="flex items-center justify-between mb-2">
+        <span className="text-sm">Show sensitive</span>
+        <input
+          type="checkbox"
+          className="toggle toggle-primary"
+          checked={prefs.show_sensitive}
+          disabled={updatingField === 'show_sensitive'}
+          onChange={handleToggle('show_sensitive')}
+        />
+      </label>
+
+      <label className="flex items-center justify-between mb-4">
+        <span className="text-sm">Blur sensitive</span>
+        <input
+          type="checkbox"
+          className="toggle toggle-primary"
+          checked={prefs.blur_sensitive}
+          disabled={updatingField === 'blur_sensitive'}
+          onChange={handleToggle('blur_sensitive')}
+        />
+      </label>
+    </div>
+  )
+}
+
+export default PreferenceSettings

--- a/frontend/src/components/settings/SettingsInner.tsx
+++ b/frontend/src/components/settings/SettingsInner.tsx
@@ -1,0 +1,21 @@
+// src/components/settings/SettingsInner.tsx
+
+'use client'
+
+import PreferenceSettings from '@/components/settings/PreferenceSettings'
+import AccountSettings from '@/components/settings/AccountSettings'
+import DeleteAccount from '@/components/settings/DeleteAccount'
+
+const SettingsInner = () => {
+  return (
+    <div className="w-full max-w-200 p-4 bg-base-200 rounded-lg">
+      <div className="flex flex-row justify-between">
+        <PreferenceSettings />
+      </div>
+      <AccountSettings />
+      <DeleteAccount />
+    </div>
+  )
+}
+
+export default SettingsInner

--- a/frontend/src/components/settings/SettingsInner.tsx
+++ b/frontend/src/components/settings/SettingsInner.tsx
@@ -4,16 +4,14 @@
 
 import PreferenceSettings from '@/components/settings/PreferenceSettings'
 import AccountSettings from '@/components/settings/AccountSettings'
-import DeleteAccount from '@/components/settings/DeleteAccount'
 
 const SettingsInner = () => {
   return (
-    <div className="w-full max-w-200 p-4 bg-base-200 rounded-lg">
-      <div className="flex flex-row justify-between">
+    <div className="flex flex-col gap-4 w-full max-w-200 p-4 bg-base-200 rounded-lg">
+      <div className="flex flex-row justify-between gap-4">
         <PreferenceSettings />
       </div>
       <AccountSettings />
-      <DeleteAccount />
     </div>
   )
 }

--- a/frontend/src/hooks/useProvideAuth.ts
+++ b/frontend/src/hooks/useProvideAuth.ts
@@ -184,5 +184,5 @@ export const useProvideAuth = () => {
     setUser(null)
   }
 
-  return { user, prefs, isLoggedIn, signIn, signUp, signOut, authFetch, updateLocalPrefs }
+  return { user, setUser, prefs, isLoggedIn, signIn, signUp, signOut, authFetch, updateLocalPrefs }
 }

--- a/frontend/src/lib/auth/validation.ts
+++ b/frontend/src/lib/auth/validation.ts
@@ -17,5 +17,25 @@ export const RegisterSchema = LoginSchema.extend({
   path: ['confirm_password'],
 })
 
+export const UpdateDetailsSchema = z.object({
+  username: z.string().min(1, 'Username is required'),
+  email_address: z.string().email('Invalid email address'),
+  first_name: z.string().min(1, 'First name is required'),
+  last_name: z.string().min(1, 'Last name is required'),
+})
+
+export const ChangePasswordSchema = z
+  .object({
+    old_password: z.string().min(1, 'Current password is required'),
+    password: z.string().min(1, 'New password is required'),
+    confirm_password: z.string().min(1, 'Please confirm new password'),
+  })
+  .refine((data) => data.password === data.confirm_password, {
+    message: 'Passwords must match',
+    path: ['confirm_password'],
+  })
+
 export type LoginForm = z.infer<typeof LoginSchema>
 export type RegisterForm = z.infer<typeof RegisterSchema>
+export type UpdateDetailsForm = z.infer<typeof UpdateDetailsSchema>
+export type ChangePasswordForm = z.infer<typeof ChangePasswordSchema>

--- a/frontend/src/lib/profile/api.ts
+++ b/frontend/src/lib/profile/api.ts
@@ -31,7 +31,7 @@ export const getUserFavs = async (
     `${BASE_URL}/${username}/favourites/?page=${page}&page_size=${pageSize}`,
   )
   if (res.status === 401 || res.status === 403) {
-    throw new Error('Private account – cannot fetch favourites')
+    throw new Error('Private account - cannot fetch favourites')
   }
   if (!res.ok) throw new Error('Failed to load favourites')
   return res.json() as Promise<PaginatedFavourites>
@@ -68,4 +68,50 @@ export const updateUserPreferences = async (
     throw new Error(`Failed to update preferences: ${res.status}`)
   }
   return (await res.json()) as UserPreferences
+}
+
+// PATCH /api/accounts/users/:username/
+export const updateUserDetails = async (
+  fetcher: typeof fetch,
+  username: string,
+  updates: Partial<Pick<User, 'first_name' | 'last_name' | 'email' | 'username'>> & {
+    password: string
+  },
+): Promise<User> => {
+  const res = await fetcher(`${BASE_URL}/${username}/`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  })
+  if (!res.ok) throw new Error(`Failed to update user: ${res.status}`)
+  return res.json()
+}
+
+// DELETE /api/accounts/users/:username/
+export const deleteUser = async (
+  fetcher: typeof fetch,
+  username: string,
+  password: string,
+): Promise<void> => {
+  const res = await fetcher(`${BASE_URL}/${username}/`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password }),
+  })
+  if (!res.ok) throw new Error(`Failed to delete user: ${res.status}`)
+}
+
+// POST /api/accounts/users/:username/password/
+export const changePassword = async (
+  fetcher: typeof fetch,
+  username: string,
+  oldPassword: string,
+  newPassword: string,
+): Promise<void> => {
+  const res = await fetcher(`${BASE_URL}/${username}/password/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ old_password: oldPassword, password: newPassword }),
+  })
+  if (!res.ok) throw new Error(`Failed to change password: ${res.status}`)
 }


### PR DESCRIPTION
This pull request introduces significant updates to both the backend and frontend to enhance user account management features, including account detail updates, password changes, account deletion, and user preferences. Backend changes focus on extending API functionality, while frontend changes implement corresponding UI components.

### Backend Changes:
1. **API Enhancements for User Management**:
   * Introduced `UserDetailUpdateDeleteView` to allow authenticated users to update or delete their accounts with password verification.
   * Added `ChangePasswordView` to enable authenticated users to change their passwords.

2. **Routing Updates**:
   * Updated `urlpatterns` in `urls.py` to include routes for the new views (`UserDetailUpdateDeleteView` and `ChangePasswordView`) and adjusted naming conventions for clarity.

3. **Authentication and Permissions**:
   * Added `JWTAuthentication` to `UserDetailView` to ensure secure access.
   * Updated permissions for `UserDetailUpdateDeleteView` to restrict actions to owners or administrators.

---

### Frontend Changes:
1. **Account Settings Page**:
   * Created a new `SettingsPage` component to serve as the entry point for account settings.

2. **Account Management Components**:
   * Added `AccountDetails` for updating user details, requiring password verification.
   * Introduced `ChangePassword` for securely changing user passwords.
   * Implemented `DeleteAccount` for account deletion with password confirmation.

3. **User Preferences**:
   * Developed `PreferenceSettings` to allow users to toggle preferences such as public profile visibility and sensitive content settings.

These changes collectively improve the user experience by providing a cohesive interface for managing account-related actions while ensuring security through authentication and password verification.