### PR TITLE
Implement media tags with conditional warnings

### DIFF
--- a/backend/core/media/serializers.py
+++ b/backend/core/media/serializers.py
@@ -38,8 +38,7 @@ class MediaSerializer(serializers.ModelSerializer):
         
     def get_tags(self, obj):
         tags = MediaTag.objects.filter(media=obj).select_related('tag')
-        names = [t.tag.name for t in tags]
-        return names
+        return [{"name": tag.tag.name, "accuracy": tag.accuracy} for tag in tags]
         
 class FavouriteSerializer(serializers.ModelSerializer):
     media = MediaSerializer()

--- a/backend/core/media/serializers.py
+++ b/backend/core/media/serializers.py
@@ -1,11 +1,12 @@
 # backend/core/media/serializers.py
 
 from rest_framework import serializers
-from core.media.models import Media, Favourite
+from core.media.models import Media, Favourite, MediaTag
 
 class MediaSerializer(serializers.ModelSerializer):
     # Annotated field for the number of favourites
     favourites_count = serializers.IntegerField(read_only=True)
+    tags = serializers.SerializerMethodField()
     
     class Meta:
         model = Media
@@ -32,7 +33,13 @@ class MediaSerializer(serializers.ModelSerializer):
             "media_type",
             "accessed_at",
             "favourites_count",
+            "tags",
         )
+        
+    def get_tags(self, obj):
+        tags = MediaTag.objects.filter(media=obj).select_related('tag')
+        names = [t.tag.name for t in tags]
+        return names
         
 class FavouriteSerializer(serializers.ModelSerializer):
     media = MediaSerializer()

--- a/backend/core/media/urls.py
+++ b/backend/core/media/urls.py
@@ -6,6 +6,4 @@ from .views import MediaDetailView, MediaFavouriteView, TagListView, SourceListV
 urlpatterns = [
     path("<str:openverse_id>/", MediaDetailView.as_view(), name="media_detail"),
     path("<str:openverse_id>/favourite/", MediaFavouriteView.as_view(), name="media_favourite"),
-    path("filters/tags/", TagListView.as_view(), name="tag_list"),
-    path("filters/sources/", SourceListView.as_view(), name="source_list"),
 ]

--- a/backend/core/media/urls.py
+++ b/backend/core/media/urls.py
@@ -1,7 +1,7 @@
 # backend/core/media/urls.py
 
 from django.urls import path
-from .views import MediaDetailView, MediaFavouriteView, TagListView, SourceListView
+from .views import MediaDetailView, MediaFavouriteView
 
 urlpatterns = [
     path("<str:openverse_id>/", MediaDetailView.as_view(), name="media_detail"),

--- a/backend/core/media/views.py
+++ b/backend/core/media/views.py
@@ -126,18 +126,3 @@ class MediaFavouriteView(APIView):
         
         return Response({"is_favourite": False}, status=status.HTTP_200_OK)
 
-class TagListView(APIView):
-    def get(self, request):
-        names = Tag.objects.values_list('name', flat=True).distinct().order_by('name')
-        return Response(names)
-
-class SourceListView(APIView):
-    def get(self, request):
-        sources = (
-            Media.objects
-            .exclude(source__isnull=True)
-            .values_list('source', flat=True)
-            .distinct()
-            .order_by('source')
-        )
-        return Response(sources)

--- a/backend/core/media/views.py
+++ b/backend/core/media/views.py
@@ -4,16 +4,13 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from django.shortcuts import get_object_or_404
-from django.http import JsonResponse
 from django.utils import timezone
-from django.views import View
 
 from core.media.models import Media, Favourite
-from core.media.models.tag import Tag
 from core.openverse_client import OpenverseClient
+from core.media.serializers import MediaSerializer
 
-
-class MediaDetailView(View):
+class MediaDetailView(APIView):
     client = OpenverseClient()
 
     def get(self, request, openverse_id):
@@ -54,35 +51,9 @@ class MediaDetailView(View):
 
         media.accessed_at = timezone.now()  # Explicit bump
         media.save()  # Save the updated media object
-
-        # Return the media details as a JSON response
-        return JsonResponse(
-            {
-                "openverse_id": media.openverse_id,
-                "title": media.title,
-                "indexed_on": media.indexed_on.isoformat(),
-                "foreign_landing_url": media.foreign_landing_url,
-                "url": media.url,
-                "creator": media.creator,
-                "creator_url": media.creator_url,
-                "license": media.license,
-                "license_version": media.license_version,
-                "license_url": media.license_url,
-                "attribution": media.attribution,
-                "source": media.source,
-                "category": media.category,
-                "file_size": media.file_size,
-                "file_type": media.file_type,
-                "mature": media.mature,
-                "thumbnail_url": media.thumbnail_url,
-                "height": media.height,
-                "width": media.width,
-                "duration": media.duration,
-                "media_type": media.media_type,
-                "accessed_at": media.accessed_at.isoformat(),
-                "favourites_count": media.favourites_count,
-            }
-        )
+        
+        serializer = MediaSerializer(media)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 class MediaFavouriteView(APIView):
     """

--- a/backend/core/search/views.py
+++ b/backend/core/search/views.py
@@ -218,9 +218,11 @@ class SearchView(APIView):
             for tag_dict in item.get("tags", []):
                 name = tag_dict.get("name")
                 accuracy = tag_dict.get("accuracy")
-                if name and isinstance(accuracy, (int, float)):
-                    tag_obj, _ = Tag.objects.get_or_create(name=name)
-                    MediaTag.objects.get_or_create(media=media, tag=tag_obj, defaults={"accuracy": accuracy})
+                if not accuracy:
+                    accuracy = 0.0
+                    
+                tag_obj, _ = Tag.objects.get_or_create(name=name)
+                MediaTag.objects.get_or_create(media=media, tag=tag_obj, defaults={"accuracy": accuracy})
 
         logger.info(f"Search complete for {search_key}'{search_value}' with {len(results)} results.")
 

--- a/backend/core/search/views.py
+++ b/backend/core/search/views.py
@@ -218,8 +218,7 @@ class SearchView(APIView):
             for tag_dict in item.get("tags", []):
                 name = tag_dict.get("name")
                 accuracy = tag_dict.get("accuracy")
-                # Only keep tags with a defined accuracy >= threshold
-                if name and isinstance(accuracy, (int, float)) and accuracy >= TAG_ACCURACY_THRESHOLD:
+                if name and isinstance(accuracy, (int, float)):
                     tag_obj, _ = Tag.objects.get_or_create(name=name)
                     MediaTag.objects.get_or_create(media=media, tag=tag_obj, defaults={"accuracy": accuracy})
 

--- a/frontend/src/components/media/MediaInner.tsx
+++ b/frontend/src/components/media/MediaInner.tsx
@@ -4,7 +4,7 @@
 
 import { useState, useEffect } from 'react'
 import { fetchMediaById } from '@/lib/media/api'
-import { notFound, useRouter } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import FullSizeImage from '@/components/media/FullSizeImage'
 import FavouriteControl from '@/components/media/FavouriteControl'
 import AttributeCard from '@/components/media/AttributeCard'
@@ -24,14 +24,13 @@ import {
   Globe as GlobeIcon,
 } from 'lucide-react'
 import LoadingSpinner from '@/components/shared/LoadingSpinner'
-import MediaTag from '@/components/media/MediaTag'
+import TagList from '@/components/media/TagList'
 
 interface MediaInnerProps {
   uuid: string
 }
 
 const MediaInner = ({ uuid }: MediaInnerProps) => {
-  const router = useRouter()
   const [media, setMedia] = useState<Media | undefined>(undefined)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
@@ -109,25 +108,9 @@ const MediaInner = ({ uuid }: MediaInnerProps) => {
               <LinkButton href={media.foreign_landing_url} />
             </div>
           </div>
-          <div className="flex flex-wrap gap-2 mb-4">
-            {media.tags && media.tags.length > 0 ? (
-              // Sort by accuracy descending, then by name
-              media.tags
-                .sort((a, b) => b.accuracy - a.accuracy || a.name.localeCompare(b.name))
-                .map((tag) => (
-                  <MediaTag
-                    key={tag.name}
-                    tag={tag.name}
-                    accuracy={tag.accuracy}
-                    onClick={() => {
-                      router.push(`/search?query=${encodeURIComponent(tag.name)}`)
-                    }}
-                  />
-                ))
-            ) : (
-              <span className="text-sm text-gray-500">No tags available</span>
-            )}
-          </div>
+
+          <TagList tags={media.tags} />
+
           <div className="flex gap-4 items-center justify-center flex-wrap">
             {media.creator && (
               <AttributeCard

--- a/frontend/src/components/media/MediaInner.tsx
+++ b/frontend/src/components/media/MediaInner.tsx
@@ -111,15 +111,19 @@ const MediaInner = ({ uuid }: MediaInnerProps) => {
           </div>
           <div className="flex flex-wrap gap-2 mb-4">
             {media.tags && media.tags.length > 0 ? (
-              media.tags.map((tag) => (
-                <MediaTag
-                  key={tag}
-                  tag={tag}
-                  onClick={() => {
-                    router.push(`/search?tag=${encodeURIComponent(tag)}`)
-                  }}
-                />
-              ))
+              // Sort by accuracy descending, then by name
+              media.tags
+                .sort((a, b) => b.accuracy - a.accuracy || a.name.localeCompare(b.name))
+                .map((tag) => (
+                  <MediaTag
+                    key={tag.name}
+                    tag={tag.name}
+                    accuracy={tag.accuracy}
+                    onClick={() => {
+                      router.push(`/search?query=${encodeURIComponent(tag.name)}`)
+                    }}
+                  />
+                ))
             ) : (
               <span className="text-sm text-gray-500">No tags available</span>
             )}

--- a/frontend/src/components/media/MediaInner.tsx
+++ b/frontend/src/components/media/MediaInner.tsx
@@ -4,7 +4,7 @@
 
 import { useState, useEffect } from 'react'
 import { fetchMediaById } from '@/lib/media/api'
-import { notFound } from 'next/navigation'
+import { notFound, useRouter } from 'next/navigation'
 import FullSizeImage from '@/components/media/FullSizeImage'
 import FavouriteControl from '@/components/media/FavouriteControl'
 import AttributeCard from '@/components/media/AttributeCard'
@@ -24,12 +24,14 @@ import {
   Globe as GlobeIcon,
 } from 'lucide-react'
 import LoadingSpinner from '@/components/shared/LoadingSpinner'
+import MediaTag from '@/components/media/MediaTag'
 
 interface MediaInnerProps {
   uuid: string
 }
 
 const MediaInner = ({ uuid }: MediaInnerProps) => {
+  const router = useRouter()
   const [media, setMedia] = useState<Media | undefined>(undefined)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
@@ -106,6 +108,21 @@ const MediaInner = ({ uuid }: MediaInnerProps) => {
               />
               <LinkButton href={media.foreign_landing_url} />
             </div>
+          </div>
+          <div className="flex flex-wrap gap-2 mb-4">
+            {media.tags && media.tags.length > 0 ? (
+              media.tags.map((tag) => (
+                <MediaTag
+                  key={tag}
+                  tag={tag}
+                  onClick={() => {
+                    router.push(`/search?tag=${encodeURIComponent(tag)}`)
+                  }}
+                />
+              ))
+            ) : (
+              <span className="text-sm text-gray-500">No tags available</span>
+            )}
           </div>
           <div className="flex gap-4 items-center justify-center flex-wrap">
             {media.creator && (

--- a/frontend/src/components/media/MediaTag.tsx
+++ b/frontend/src/components/media/MediaTag.tsx
@@ -8,8 +8,12 @@ interface MediaTagProps {
   onClick?: (tag: string) => void
 }
 
+const ACCURACY_THRESHOLD = 0.5 // Threshold for low confidence tags
+const MIN_OPACITY = 0.3 // Minimum opacity for tags with low accuracy
+
 const MediaTag = ({ tag, accuracy = 1, onClick }: MediaTagProps) => {
-  const inaccurate = accuracy < 0.5
+  const inaccurate = accuracy < ACCURACY_THRESHOLD
+  const opacity = Math.max(accuracy, MIN_OPACITY)
 
   const handleClick = () => {
     if (onClick) {
@@ -20,13 +24,14 @@ const MediaTag = ({ tag, accuracy = 1, onClick }: MediaTagProps) => {
   return (
     <div
       onClick={handleClick}
+      style={{ opacity }}
       className={`
-        flex items-center cursor-pointer px-2 py-0 rounded-sm w-fit h-6
-        ${inaccurate ? 'bg-primary/20 hover:bg-primary/60 text-primary-content/60' : 'bg-primary hover:bg-primary/60'} gap-1 text-xs align-middle
+        flex items-center cursor-pointer px-2 py-0.5 rounded-sm h-6 gap-1
+        bg-primary hover:underline text-xs font-medium
       `}
     >
-      <p>{tag}</p>
-      {inaccurate && <AlertIcon className="text-yellow-500" size={14} strokeWidth={2} />}
+      <p>{tag.toUpperCase()}</p>
+      {inaccurate && <AlertIcon className="text-yellow-500" size={14} strokeWidth={3} />}
     </div>
   )
 }

--- a/frontend/src/components/media/MediaTag.tsx
+++ b/frontend/src/components/media/MediaTag.tsx
@@ -8,12 +8,30 @@ interface MediaTagProps {
   onClick?: (tag: string) => void
 }
 
-const ACCURACY_THRESHOLD = 0.5 // Threshold for low confidence tags
 const MIN_OPACITY = 0.3 // Minimum opacity for tags with low accuracy
+const COLOURS = {
+  red: 'text-red-500',
+  orange: 'text-orange-500',
+  yellow: 'text-yellow-500',
+  green: 'text-green-500',
+}
 
 const MediaTag = ({ tag, accuracy = 1, onClick }: MediaTagProps) => {
-  const inaccurate = accuracy < ACCURACY_THRESHOLD
   const opacity = Math.max(accuracy, MIN_OPACITY)
+
+  // Pick icon colour band
+  let iconClass = ''
+  if (accuracy < 0.25) {
+    iconClass = COLOURS.red
+  } else if (accuracy < 0.5) {
+    iconClass = COLOURS.orange
+  } else if (accuracy < 0.75) {
+    iconClass = COLOURS.yellow
+  } else {
+    iconClass = COLOURS.green
+  }
+
+  const showIcon = accuracy < 0.75
 
   const handleClick = () => {
     if (onClick) {
@@ -27,11 +45,11 @@ const MediaTag = ({ tag, accuracy = 1, onClick }: MediaTagProps) => {
       style={{ opacity }}
       className={`
         flex items-center cursor-pointer px-2 py-0.5 rounded-sm h-6 gap-1
-        bg-primary hover:underline text-xs font-medium
+        bg-primary text-primary-content/100 hover:underline text-xs font-medium
       `}
     >
       <p>{tag.toUpperCase()}</p>
-      {inaccurate && <AlertIcon className="text-yellow-500" size={14} strokeWidth={3} />}
+      {showIcon && <AlertIcon className={iconClass} size={14} strokeWidth={3} />}
     </div>
   )
 }

--- a/frontend/src/components/media/MediaTag.tsx
+++ b/frontend/src/components/media/MediaTag.tsx
@@ -1,0 +1,25 @@
+// src/components/media/MediaTag.tsx
+
+interface MediaTagProps {
+  tag: string
+  onClick?: (tag: string) => void
+}
+
+const MediaTag = ({ tag, onClick }: MediaTagProps) => {
+  const handleClick = () => {
+    if (onClick) {
+      onClick(tag)
+    }
+  }
+
+  return (
+    <span
+      className="cursor-pointer text-sm bg-primary hover:opacity-60 hover:underline px-2 py-1 rounded-sm"
+      onClick={handleClick}
+    >
+      {tag}
+    </span>
+  )
+}
+
+export default MediaTag

--- a/frontend/src/components/media/MediaTag.tsx
+++ b/frontend/src/components/media/MediaTag.tsx
@@ -1,11 +1,16 @@
 // src/components/media/MediaTag.tsx
 
+import { TriangleAlert as AlertIcon } from 'lucide-react'
+
 interface MediaTagProps {
   tag: string
+  accuracy?: number
   onClick?: (tag: string) => void
 }
 
-const MediaTag = ({ tag, onClick }: MediaTagProps) => {
+const MediaTag = ({ tag, accuracy = 1, onClick }: MediaTagProps) => {
+  const innaccurate = accuracy < 0.5
+
   const handleClick = () => {
     if (onClick) {
       onClick(tag)
@@ -13,12 +18,16 @@ const MediaTag = ({ tag, onClick }: MediaTagProps) => {
   }
 
   return (
-    <span
-      className="cursor-pointer text-sm bg-primary hover:opacity-60 hover:underline px-2 py-1 rounded-sm"
+    <div
       onClick={handleClick}
+      className={`
+        flex items-center cursor-pointer px-2 py-0 rounded-sm w-fit h-6
+        ${innaccurate ? 'bg-primary/20 hover:bg-primary/60 text-primary-content/60' : 'bg-primary hover:bg-primary/60'} gap-1 text-xs align-middle
+      `}
     >
-      {tag}
-    </span>
+      <p>{tag}</p>
+      {innaccurate && <AlertIcon className="text-yellow-500" size={14} strokeWidth={2} />}
+    </div>
   )
 }
 

--- a/frontend/src/components/media/MediaTag.tsx
+++ b/frontend/src/components/media/MediaTag.tsx
@@ -9,7 +9,7 @@ interface MediaTagProps {
 }
 
 const MediaTag = ({ tag, accuracy = 1, onClick }: MediaTagProps) => {
-  const innaccurate = accuracy < 0.5
+  const inaccurate = accuracy < 0.5
 
   const handleClick = () => {
     if (onClick) {
@@ -22,11 +22,11 @@ const MediaTag = ({ tag, accuracy = 1, onClick }: MediaTagProps) => {
       onClick={handleClick}
       className={`
         flex items-center cursor-pointer px-2 py-0 rounded-sm w-fit h-6
-        ${innaccurate ? 'bg-primary/20 hover:bg-primary/60 text-primary-content/60' : 'bg-primary hover:bg-primary/60'} gap-1 text-xs align-middle
+        ${inaccurate ? 'bg-primary/20 hover:bg-primary/60 text-primary-content/60' : 'bg-primary hover:bg-primary/60'} gap-1 text-xs align-middle
       `}
     >
       <p>{tag}</p>
-      {innaccurate && <AlertIcon className="text-yellow-500" size={14} strokeWidth={2} />}
+      {inaccurate && <AlertIcon className="text-yellow-500" size={14} strokeWidth={2} />}
     </div>
   )
 }

--- a/frontend/src/components/media/TagList.tsx
+++ b/frontend/src/components/media/TagList.tsx
@@ -3,12 +3,15 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import { AlertTriangle as AlertIcon } from 'lucide-react'
 import type { Tag } from '@/lib/media/types'
 import MediaTag from '@/components/media/MediaTag'
 
 interface TagListProps {
   tags: Tag[] | undefined
 }
+
+const ACCURACY_THRESHOLD = 0.5 // Threshold for low confidence tags
 
 const TagList = ({ tags }: TagListProps) => {
   const router = useRouter()
@@ -17,20 +20,29 @@ const TagList = ({ tags }: TagListProps) => {
     return <p className="text-sm text-gray-500">No tags available</p>
   }
 
+  // Sort highest accuracy first, then by name
+  const sorted = [...tags].sort((a, b) => b.accuracy - a.accuracy || a.name.localeCompare(b.name))
+
+  // do we have any low-confidence tags?
+  const hasLow = sorted.some((tag) => tag.accuracy < ACCURACY_THRESHOLD)
+
   return (
-    <div className="flex flex-wrap gap-2 mb-4">
-      {tags
-        .sort((a, b) => b.accuracy - a.accuracy || a.name.localeCompare(b.name))
-        .map((tag) => (
-          <MediaTag
-            key={tag.name}
-            tag={tag.name}
-            accuracy={tag.accuracy}
-            onClick={() => {
-              router.push(`/search?query=${encodeURIComponent(tag.name)}`)
-            }}
-          />
-        ))}
+    <div className="flex flex-wrap gap-2 mb-4 items-center">
+      {sorted.map((tag) => (
+        <MediaTag
+          key={tag.name}
+          tag={tag.name}
+          accuracy={tag.accuracy}
+          onClick={() => router.push(`/search?query=${encodeURIComponent(tag.name)}`)}
+        />
+      ))}
+
+      {hasLow && (
+        <div className="flex items-center text-yellow-500 text-xs gap-1">
+          <AlertIcon size={14} strokeWidth={2} />
+          <span>Some tags may be inaccurate</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/media/TagList.tsx
+++ b/frontend/src/components/media/TagList.tsx
@@ -3,15 +3,13 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { AlertTriangle as AlertIcon } from 'lucide-react'
+import { AlertTriangle as AlertIcon, CircleCheck as CheckIcon } from 'lucide-react'
 import type { Tag } from '@/lib/media/types'
 import MediaTag from '@/components/media/MediaTag'
 
 interface TagListProps {
   tags: Tag[] | undefined
 }
-
-const ACCURACY_THRESHOLD = 0.5 // Threshold for low confidence tags
 
 const TagList = ({ tags }: TagListProps) => {
   const router = useRouter()
@@ -23,8 +21,10 @@ const TagList = ({ tags }: TagListProps) => {
   // Sort highest accuracy first, then by name
   const sorted = [...tags].sort((a, b) => b.accuracy - a.accuracy || a.name.localeCompare(b.name))
 
-  // do we have any low-confidence tags?
-  const hasLow = sorted.some((tag) => tag.accuracy < ACCURACY_THRESHOLD)
+  const anyRed = sorted.some((tag) => tag.accuracy < 0.25)
+  const anyOrange = sorted.some((tag) => tag.accuracy < 0.5)
+  const anyYellow = sorted.some((tag) => tag.accuracy < 0.75)
+  const allGreen = sorted.every((tag) => tag.accuracy >= 0.9)
 
   return (
     <div className="flex flex-wrap gap-2 mb-4 items-center">
@@ -37,10 +37,28 @@ const TagList = ({ tags }: TagListProps) => {
         />
       ))}
 
-      {hasLow && (
-        <div className="flex items-center text-yellow-500 text-xs gap-1">
-          <AlertIcon size={14} strokeWidth={2} />
-          <span>Some tags may be inaccurate</span>
+      {anyRed && (
+        <div className="flex items-center text-red-500 text-sm gap-1">
+          <AlertIcon size={16} strokeWidth={2} />
+          <span>Some tags are very inaccurate</span>
+        </div>
+      )}
+      {!anyRed && anyOrange && (
+        <div className="flex items-center text-orange-500 text-sm gap-1">
+          <AlertIcon size={16} strokeWidth={2} />
+          <span>Some tags are inaccurate</span>
+        </div>
+      )}
+      {!anyOrange && anyYellow && (
+        <div className="flex items-center text-yellow-500 text-sm gap-1">
+          <AlertIcon size={16} strokeWidth={2} />
+          <span>Some tags have low confidence</span>
+        </div>
+      )}
+      {allGreen && (
+        <div className="flex items-center text-green-500 text-sm gap-1">
+          <CheckIcon size={16} strokeWidth={2} />
+          <span>All tags are very accurate</span>
         </div>
       )}
     </div>

--- a/frontend/src/components/media/TagList.tsx
+++ b/frontend/src/components/media/TagList.tsx
@@ -1,0 +1,38 @@
+// src/components/media/TagList.tsx
+
+'use client'
+
+import { useRouter } from 'next/navigation'
+import type { Tag } from '@/lib/media/types'
+import MediaTag from '@/components/media/MediaTag'
+
+interface TagListProps {
+  tags: Tag[] | undefined
+}
+
+const TagList = ({ tags }: TagListProps) => {
+  const router = useRouter()
+
+  if (!tags || tags.length === 0) {
+    return <p className="text-sm text-gray-500">No tags available</p>
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-4">
+      {tags
+        .sort((a, b) => b.accuracy - a.accuracy || a.name.localeCompare(b.name))
+        .map((tag) => (
+          <MediaTag
+            key={tag.name}
+            tag={tag.name}
+            accuracy={tag.accuracy}
+            onClick={() => {
+              router.push(`/search?query=${encodeURIComponent(tag.name)}`)
+            }}
+          />
+        ))}
+    </div>
+  )
+}
+
+export default TagList

--- a/frontend/src/lib/media/types.ts
+++ b/frontend/src/lib/media/types.ts
@@ -24,4 +24,5 @@ export interface Media {
   media_type: 'image' | 'audio'
   accessed_at?: string // Only present in MediaDetailView
   favourites_count?: number
+  tags?: string[]
 }

--- a/frontend/src/lib/media/types.ts
+++ b/frontend/src/lib/media/types.ts
@@ -1,5 +1,10 @@
 // src/lib/media/types.ts
 
+export interface Tag {
+  name: string
+  accuracy: number
+}
+
 export interface Media {
   openverse_id: string
   title: string
@@ -24,5 +29,5 @@ export interface Media {
   media_type: 'image' | 'audio'
   accessed_at?: string // Only present in MediaDetailView
   favourites_count?: number
-  tags?: string[]
+  tags?: Tag[]
 }


### PR DESCRIPTION
This pull request introduces a tagging system for media items, enhancing both the backend and frontend to support tags with accuracy levels. The changes include modifications to serializers, views, and APIs in the backend, as well as new components and updates in the frontend to display and interact with tags.

### Backend Changes

#### Tagging System Integration:
* Added `tags` as a computed field in the `MediaSerializer`, which retrieves tags associated with a media item along with their accuracy levels. (`backend/core/media/serializers.py`) [[1]](diffhunk://#diff-4ee8441476366a2b9e9a7985322da6d1554a5636538dfcd0b016cd0d8af4d2b5L4-R9) [[2]](diffhunk://#diff-4ee8441476366a2b9e9a7985322da6d1554a5636538dfcd0b016cd0d8af4d2b5R36-R42)
* Removed unused `TagListView` and `SourceListView` endpoints, simplifying the API. (`backend/core/media/urls.py`, `backend/core/media/views.py`) [[1]](diffhunk://#diff-4cf3879b0a7fa65aa3affa9972a4345ec26da43ff4e3b2f68987af393c13c6faL4-L10) [[2]](diffhunk://#diff-14ef1cee3ee9f676d7234a761383994bea25442e2bd33578f9477918027fdb71L129-L143)

#### Refactoring:
* Replaced manual JSON response construction in `MediaDetailView` with the use of `MediaSerializer` for cleaner and more maintainable code. (`backend/core/media/views.py`)

### Frontend Changes

#### New Components:
* Added a `MediaTag` component to display individual tags with visual indicators based on accuracy. (`frontend/src/components/media/MediaTag.tsx`)
* Created a `TagList` component to display a list of tags, sorted by accuracy, and provide feedback on their overall confidence levels. (`frontend/src/components/media/TagList.tsx`)

#### Media Details Enhancement:
* Integrated the `TagList` component into the `MediaInner` component to display tags for media items on the frontend. (`frontend/src/components/media/MediaInner.tsx`) [[1]](diffhunk://#diff-23a91510acd500df84841977eec27ec36069c7ee743352b71a808e8d6287aa27R27) [[2]](diffhunk://#diff-23a91510acd500df84841977eec27ec36069c7ee743352b71a808e8d6287aa27R111-R113)

#### Type Updates:
* Updated the `Media` interface in the frontend to include an optional `tags` field, which is an array of tag objects containing `name` and `accuracy`. (`frontend/src/lib/media/types.ts`) [[1]](diffhunk://#diff-6e9a60b4547ed24fb34a6e54cdb35e194370096c59c19fe26896aa850c3fdd76R3-R7) [[2]](diffhunk://#diff-6e9a60b4547ed24fb34a6e54cdb35e194370096c59c19fe26896aa850c3fdd76R32)

### Closes #28 