### PR TITLE
Fix issue with docker compose installing frontend dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
       - .env
     volumes:
       - ./frontend:/app/frontend:z
-      - node_modules:/app/frontend/node_modules:z
     depends_on:
       - backend
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,4 +22,5 @@ RUN npm run build
 EXPOSE 3000
 
 # Uncomment the line below to run in development mode with live reloading
-CMD ["npm", "run", "dev"]
+CMD ["sh", "-c", "npm install && npm run dev"]
+


### PR DESCRIPTION
This pull request includes updates to the Docker configuration for the frontend service. The changes aim to improve the setup process and streamline development workflows.

### Docker configuration updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L39): Removed the `node_modules` volume mapping for the frontend service to avoid conflicts and ensure a cleaner environment during container builds.
* [`frontend/Dockerfile`](diffhunk://#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8L25-R26): Updated the `CMD` instruction to include `npm install` before running the development server, ensuring dependencies are installed automatically when the container starts.

### Closes #49 